### PR TITLE
Update EventSubscriptionId length to 128 characters

### DIFF
--- a/working/v3.0.0-draft2/event-notification-openapi.yaml
+++ b/working/v3.0.0-draft2/event-notification-openapi.yaml
@@ -603,6 +603,8 @@ components:
           properties:
             EventSubscriptionId:
               type: string
+              minLength: 1
+              maxLength: 128
           additionalProperties: false
           required:
             - EventSubscriptionId


### PR DESCRIPTION
Previously, the documented length (although not included in the OpenAPI spec) of EventSubscriptionId was listed as 40 characters.  This PR updates the OpenAPI specification to use `minLength: 1` and `maxLength: 128`, to align with other specifications and reflect the [TWG tech decision 047](https://paymentsnz.atlassian.net/wiki/spaces/PaymentsDirectionAPIStandardsDevelopment/pages/1610940428/Technical+Decision+-+047+-+Resource+ID+Length)